### PR TITLE
changeing data-original setter

### DIFF
--- a/lib/action_view/helpers/image_tag_helper.rb
+++ b/lib/action_view/helpers/image_tag_helper.rb
@@ -7,7 +7,7 @@ module ActionView
         orig_options = options.dup
 
         options[:data] ||= {}
-        options[:data] = {original: path_to_image(source)}
+        options[:data][:original] = path_to_image(source)
         options[:class] ||= ""
         options[:class] << " lazy"
 


### PR DESCRIPTION
previous options[:data][:original] setter overwrote all data options to only include data-original instead of only setting data-orignal.
